### PR TITLE
Python: Publish PySparkler to PyPI in Release Workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,3 +19,18 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+  pypi-publish-pysparkler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: |
+          cd pysparkler
+          make install
+          make build
+      - name: Publish PySparkler Package on PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYSPARKLER_PYPI_API_TOKEN }} # Need Holden to add this as a repo secret

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ project/metals.sbt
 **/.idea/*
 **/venv/*
 *.iml
+**/dist/*

--- a/pysparkler/Makefile
+++ b/pysparkler/Makefile
@@ -7,3 +7,6 @@ lint:
 
 test:
 	poetry run pytest tests/ ${PYTEST_ARGS}
+
+build:
+	poetry build


### PR DESCRIPTION
Publish PySparkler to PyPI in Release Workflow. Need @holdenk to add `PYSPARKLER_PYPI_API_TOKEN` as a repo secret so that GitHub Action is authorized to publish PySparkler to PyPI.