### PR TITLE
PySparkler: Upgrade Pyspark 2.4 to 3.0 using guidelines

### DIFF
--- a/pysparkler/.gitignore
+++ b/pysparkler/.gitignore
@@ -1,0 +1,2 @@
+**/.pytest_cache/
+**/__pycache__/

--- a/pysparkler/.pre-commit-config.yaml
+++ b/pysparkler/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: check-yaml
       - id: check-ast
   - repo: https://github.com/ambv/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-isort
@@ -21,7 +21,7 @@ repos:
       - id: isort
         args: [ --settings-path=pysparkler/pyproject.toml ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.1.1
     hooks:
       - id: mypy
         args: [ --install-types, --non-interactive, --config=pysparkler/pyproject.toml]
@@ -34,17 +34,17 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: [ --py38-plus, --keep-runtime-typing ]
+        args: [ --py310-plus, --keep-runtime-typing ]
   - repo: https://github.com/pycqa/pylint
-    rev: v2.16.0
+    rev: v2.17.1
     hooks:
       - id: pylint
         args: [ --rcfile=pysparkler/pylintrc ]
   - repo: https://github.com/pycqa/flake8
-    rev: '6.0.0'
+    rev: 6.0.0
     hooks:
       - id: flake8
-        args: [ "--ignore=E501,W503,E203,B024" ]
+        args: [ "--ignore=E501" ]
         additional_dependencies: [ flake8-bugbear==22.12.6, flake8-comprehensions==3.10.1 ]
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.16

--- a/pysparkler/.pre-commit-config.yaml
+++ b/pysparkler/.pre-commit-config.yaml
@@ -19,33 +19,44 @@ repos:
     rev: v5.10.1
     hooks:
       - id: isort
-        args: [ --settings-path=pysparkler/pyproject.toml ]
+        args:
+          - --settings-path=pysparkler/pyproject.toml
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.1.1
     hooks:
       - id: mypy
-        args: [ --install-types, --non-interactive, --config=pysparkler/pyproject.toml]
+        args:
+          - --install-types
+          - --non-interactive
+          - --config=pysparkler/pyproject.toml
   - repo: https://github.com/hadialqattan/pycln
     rev: v2.1.3
     hooks:
       - id: pycln
-        args: [--config=pysparkler/pyproject.toml]
+        args:
+          - --config=pysparkler/pyproject.toml
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: [ --py310-plus, --keep-runtime-typing ]
+        args:
+          - --py310-plus
+          - --keep-runtime-typing
   - repo: https://github.com/pycqa/pylint
     rev: v2.17.1
     hooks:
       - id: pylint
-        args: [ --rcfile=pysparkler/pylintrc ]
+        args:
+          - --rcfile=pysparkler/pylintrc
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
       - id: flake8
-        args: [ "--ignore=E501" ]
-        additional_dependencies: [ flake8-bugbear==22.12.6, flake8-comprehensions==3.10.1 ]
+        args:
+          - --ignore=E501
+        additional_dependencies:
+          - flake8-bugbear
+          - flake8-comprehensions
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.16
     hooks:

--- a/pysparkler/.pre-commit-config.yaml
+++ b/pysparkler/.pre-commit-config.yaml
@@ -41,7 +41,6 @@ repos:
       - id: pyupgrade
         args:
           - --py310-plus
-          - --keep-runtime-typing
   - repo: https://github.com/pycqa/pylint
     rev: v2.17.1
     hooks:

--- a/pysparkler/pyproject.toml
+++ b/pysparkler/pyproject.toml
@@ -31,3 +31,7 @@ build-backend = "poetry.core.masonry.api"
 [[tool.mypy.overrides]]
 module = "libcst.*"
 ignore_missing_imports = true
+
+[tool.isort]
+src_paths = ["pysparkler/", "tests/"]
+profile = 'black'

--- a/pysparkler/pyproject.toml
+++ b/pysparkler/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysparkler"
-version = "0.1.dev"
+version = "0.2.dev"
 description = "A tool that upgrades your PySpark scripts to Spark 3.3 as per Spark migration Guideline"
 authors = ["Dhruv Pratap <dhruv.pratap@gmail.com>"]
 readme = "README.md"

--- a/pysparkler/pysparkler/__init__.py
+++ b/pysparkler/pysparkler/__init__.py
@@ -67,3 +67,14 @@ def add_comment_to_end_of_a_simple_statement_line(
                 ),
             )
         )
+
+
+def one_of_matching_strings(*strings: str) -> m.OneOf[m.SimpleString]:
+    """Returns a one of matcher that matches a string regardless of the quotes used"""
+    return m.OneOf(
+        *[
+            m.SimpleString(value=quoted_str)
+            for string in strings
+            for quoted_str in (f'"{string}"', f"'{string}'")
+        ]
+    )

--- a/pysparkler/pysparkler/__init__.py
+++ b/pysparkler/pysparkler/__init__.py
@@ -19,22 +19,8 @@ import libcst as cst
 import libcst.matchers as m
 
 
-class BaseTransformer(cst.CSTTransformer):
+class BaseTransformer(m.MatcherDecoratableTransformer):
     """Base class for all transformers.
-
-    Attributes:
-        transformer_id: A unique identifier for the transformer rule. Follows the format PY<From-Major-Version>-<To-Major-Version>-<Rule-Number>
-            Important for idempotency checks and debugging.
-
-    """
-
-    def __init__(self, transformer_id: str):
-        super().__init__()
-        self.transformer_id = transformer_id
-
-
-class BaseMatcherDecoratableTransformer(m.MatcherDecoratableTransformer):
-    """Base class for all Matcher Decoratable Transformers.
 
     Attributes:
         transformer_id: A unique identifier for the transformer rule. Follows the format PY<From-Major-Version>-<To-Major-Version>-<Rule-Number>

--- a/pysparkler/pysparkler/pyspark_24_to_30.py
+++ b/pysparkler/pysparkler/pyspark_24_to_30.py
@@ -1,0 +1,115 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#  #
+#    http://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+
+import libcst as cst
+
+from pysparkler import BaseTransformer
+
+# Migration rules for PySpark 2.4 to 3.0
+# https://spark.apache.org/docs/latest/api/python/migration_guide/pyspark_2.4_to_3.0.html
+
+
+class RequiredDependencyVersionCommentWriter(BaseTransformer):
+    """Base class for adding comments to the import statements of required dependencies version of PySpark"""
+
+    def __init__(
+        self,
+        transformer_id: str,
+        pyspark_version: str,
+        required_dependency_name: str,
+        required_dependency_version: str,
+    ):
+        super().__init__(transformer_id)
+        self.pyspark_version = pyspark_version
+        self.required_dependency_version = required_dependency_version
+        self.required_dependency_name = required_dependency_name
+
+    def leave_SimpleStatementLine(self, original_node, updated_node):
+        """Add a comment to the dependency import statement"""
+        match_found = False
+        for child in original_node.body:
+            if isinstance(child, cst.Import):
+                for alias in child.names:
+                    if alias.name.value == self.required_dependency_name:
+                        match_found = True
+                        break
+            elif isinstance(child, cst.ImportFrom):
+                if (
+                    child.module is not None
+                    and child.module.value == self.required_dependency_name
+                ):
+                    match_found = True
+                    break
+
+        if match_found:
+            return self._add_comment(updated_node)
+        else:
+            return updated_node
+
+    def _add_comment(self, node: cst.SimpleStatementLine) -> cst.SimpleStatementLine:
+        """Add a trailing whitespace and comment to the node"""
+
+        if node.trailing_whitespace.comment:
+            # If there is already a comment
+            if self.transformer_id in node.trailing_whitespace.comment.value:
+                # If the comment is already added by this transformer, do nothing
+                return node
+            else:
+                # Add the comment to the end of the comments
+                return node.with_changes(
+                    trailing_whitespace=cst.TrailingWhitespace(
+                        whitespace=node.trailing_whitespace.whitespace,
+                        comment=node.trailing_whitespace.comment.with_changes(
+                            value=f"{node.trailing_whitespace.comment.value}  # {self.transformer_id}: PySpark {self.pyspark_version} requires {self.required_dependency_name} version {self.required_dependency_version} or higher",
+                        ),
+                        newline=node.trailing_whitespace.newline,
+                    )
+                )
+        else:
+            # If there is no comment, add a comment to the trailing whitespace
+            return node.with_changes(
+                trailing_whitespace=cst.TrailingWhitespace(
+                    whitespace=cst.SimpleWhitespace(
+                        value="  ",
+                    ),
+                    comment=cst.Comment(
+                        value=f"# {self.transformer_id}: PySpark {self.pyspark_version} requires {self.required_dependency_name} version {self.required_dependency_version} or higher",
+                    ),
+                    newline=cst.Newline(
+                        value=None,
+                    ),
+                )
+            )
+
+
+class RequiredPandasVersionCommentWriter(RequiredDependencyVersionCommentWriter):
+    """In Spark 3.0, PySpark requires a pandas version of 0.23.2 or higher to use pandas related functionality,
+    such as toPandas, createDataFrame from pandas DataFrame, and so on."""
+
+    def __init__(
+        self,
+        pyspark_version: str = "3.0",
+        required_dependency_name: str = "pandas",
+        required_dependency_version: str = "0.23.2",
+    ):
+        super().__init__(
+            transformer_id="PY24-30-001",
+            pyspark_version=pyspark_version,
+            required_dependency_name=required_dependency_name,
+            required_dependency_version=required_dependency_version,
+        )

--- a/pysparkler/pysparkler/pyspark_24_to_30.py
+++ b/pysparkler/pysparkler/pyspark_24_to_30.py
@@ -141,9 +141,9 @@ class ToPandasUsageTransformer(StatementLineCommentWriter):
             comment=f"PySpark {pyspark_version} requires a {required_dependency_name} version of {required_dependency_version} or higher to use toPandas()",
         )
 
-    def visit_Attribute(self, node: cst.Attribute) -> None:
-        """Check if toPandas is being used"""
-        if m.matches(node, m.Attribute(attr=m.Name("toPandas"))):
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if toPandas is being called"""
+        if m.matches(node, m.Call(func=m.Attribute(attr=m.Name("toPandas")))):
             self.match_found = True
 
 

--- a/pysparkler/pysparkler/pyspark_24_to_30.py
+++ b/pysparkler/pysparkler/pyspark_24_to_30.py
@@ -255,3 +255,34 @@ class CreateDataFrameVerifySchemaCommentWriter(StatementLineCommentWriter):
             ),
         ):
             self.match_found = True
+
+
+class RowFieldNamesNotSortedCommentWriter(StatementLineCommentWriter):
+    """As of Spark 3.0, Row field names are no longer sorted alphabetically when constructing with named arguments for
+    Python versions 3.6 and above, and the order of fields will match that as entered. For Python versions less than
+    3.6, the field names will be sorted alphabetically as the only option.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "3.0",
+    ):
+        super().__init__(
+            transformer_id="PY24-30-007",
+            comment=f"As of Spark {pyspark_version}, Row field names are no longer sorted alphabetically when constructing with named arguments.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if Row(...) is being called with named arguments"""
+        if m.matches(
+            node,
+            m.Call(
+                func=m.Name("Row"),
+                args=[
+                    m.ZeroOrMore(),
+                    m.Arg(keyword=m.Name()),
+                    m.ZeroOrMore(),
+                ],
+            ),
+        ):
+            self.match_found = True

--- a/pysparkler/pysparkler/pyspark_24_to_30.py
+++ b/pysparkler/pysparkler/pyspark_24_to_30.py
@@ -188,11 +188,16 @@ class PyArrowEnabledCommentWriter(StatementLineCommentWriter):
         if m.matches(
             node,
             m.Call(
-                func=m.Attribute(
-                    value=m.Attribute(
-                        attr=m.Name("conf"),
+                func=m.OneOf(
+                    m.Attribute(
+                        value=m.Attribute(
+                            attr=m.Name("conf"),
+                        ),
+                        attr=m.Name("set"),
                     ),
-                    attr=m.Name("set"),
+                    m.Attribute(
+                        attr=m.Name("config"),
+                    ),
                 ),
                 args=[
                     m.Arg(

--- a/pysparkler/pysparkler/pyspark_24_to_30.py
+++ b/pysparkler/pysparkler/pyspark_24_to_30.py
@@ -286,3 +286,37 @@ class RowFieldNamesNotSortedCommentWriter(StatementLineCommentWriter):
             ),
         ):
             self.match_found = True
+
+
+class MlParamMixinsSetterCommentWriter(StatementLineCommentWriter):
+    """In Spark 3.0, pyspark.ml.param.shared.Has* mixins do not provide any set*(self, value) setter methods anymore,
+    use the respective self.set(self.*, value) instead. See SPARK-29093 for details.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "3.0",
+    ):
+        super().__init__(
+            transformer_id="PY24-30-008",
+            comment=f"In Spark {pyspark_version}, pyspark.ml.param.shared.Has* mixins do not provide any set*(self, value) setter methods anymore, use the respective self.set(self.*, value) instead.",
+        )
+
+    def visit_ImportFrom(self, node: cst.ImportFrom) -> None:
+        """Check if pyspark.ml.param.shared is being used in a from import statement"""
+        if m.matches(
+            node,
+            m.ImportFrom(
+                module=m.Attribute(
+                    value=m.Attribute(
+                        value=m.Attribute(
+                            value=m.Name("pyspark"),
+                            attr=m.Name("ml"),
+                        ),
+                        attr=m.Name("param"),
+                    ),
+                    attr=m.Name("shared"),
+                ),
+            ),
+        ):
+            self.match_found = True

--- a/pysparkler/pysparkler/pyspark_24_to_30.py
+++ b/pysparkler/pysparkler/pyspark_24_to_30.py
@@ -189,15 +189,8 @@ class PyArrowEnabledCommentWriter(StatementLineCommentWriter):
             node,
             m.Call(
                 func=m.OneOf(
-                    m.Attribute(
-                        value=m.Attribute(
-                            attr=m.Name("conf"),
-                        ),
-                        attr=m.Name("set"),
-                    ),
-                    m.Attribute(
-                        attr=m.Name("config"),
-                    ),
+                    m.Attribute(attr=m.Name("set")),
+                    m.Attribute(attr=m.Name("config")),
                 ),
                 args=[
                     m.Arg(

--- a/pysparkler/tests/conftest.py
+++ b/pysparkler/tests/conftest.py
@@ -18,15 +18,8 @@
 import libcst as cst
 
 
-class BaseTransformer(cst.CSTTransformer):
-    """Base class for all transformers.
-
-    Attributes:
-        transformer_id: A unique identifier for the transformer rule. Follows the format PY<From-Major-Version>-<To-Major-Version>-<Rule-Number>
-            Important for idempotency checks and debugging.
-
-    """
-
-    def __init__(self, transformer_id: str):
-        super().__init__()
-        self.transformer_id = transformer_id
+def rewrite(given_code: str, cst_transformer: cst.CSTTransformer):
+    given_tree = cst.parse_module(given_code)
+    modified_tree = given_tree.visit(cst_transformer)
+    modified_code = modified_tree.code
+    return modified_code

--- a/pysparkler/tests/test_pyspark_24_to_30.py
+++ b/pysparkler/tests/test_pyspark_24_to_30.py
@@ -18,6 +18,7 @@
 
 from pysparkler.pyspark_24_to_30 import (
     PandasUdfUsageTransformer,
+    PyArrowEnabledCommentWriter,
     RequiredPandasVersionCommentWriter,
     ToPandasUsageTransformer,
 )
@@ -171,5 +172,51 @@ from pyspark.sql.functions import pandas_udf, PandasUDFType  # PY24-30-003: PySp
 from pyspark.sql.types import IntegerType, StringType
 
 str_len = pandas_udf(lambda s: s.str.len(), IntegerType())
+"""
+    assert modified_code == expected_code
+
+
+def test_writes_comment_when_spark_sql_execution_arrow_enabled():
+    given_code = """\
+import numpy as np
+import pandas as pd
+
+spark.conf.set("spark.sql.execution.arrow.enabled", "true")
+pdf = pd.DataFrame(np.random.rand(100, 3))
+df = spark.createDataFrame(pdf)
+result_pdf = df.select("*").toPandas()
+"""
+    modified_code = rewrite(given_code, PyArrowEnabledCommentWriter())
+    expected_code = """\
+import numpy as np
+import pandas as pd
+
+spark.conf.set("spark.sql.execution.arrow.enabled", "true")  # PY24-30-004: PySpark 3.0 requires PyArrow version 0.12.1 or higher when spark.sql.execution.arrow.enabled is set to true
+pdf = pd.DataFrame(np.random.rand(100, 3))
+df = spark.createDataFrame(pdf)
+result_pdf = df.select("*").toPandas()
+"""
+    assert modified_code == expected_code
+
+
+def test_writes_comment_when_spark_sql_execution_arrow_pyspark_enabled():
+    given_code = """\
+import numpy as np
+import pandas as pd
+
+spark.conf.set("spark.sql.execution.arrow.pyspark.enabled", "true")
+pdf = pd.DataFrame(np.random.rand(100, 3))
+df = spark.createDataFrame(pdf)
+result_pdf = df.select("*").toPandas()
+"""
+    modified_code = rewrite(given_code, PyArrowEnabledCommentWriter())
+    expected_code = """\
+import numpy as np
+import pandas as pd
+
+spark.conf.set("spark.sql.execution.arrow.pyspark.enabled", "true")  # PY24-30-004: PySpark 3.0 requires PyArrow version 0.12.1 or higher when spark.sql.execution.arrow.enabled is set to true
+pdf = pd.DataFrame(np.random.rand(100, 3))
+df = spark.createDataFrame(pdf)
+result_pdf = df.select("*").toPandas()
 """
     assert modified_code == expected_code

--- a/pysparkler/tests/test_pyspark_24_to_30.py
+++ b/pysparkler/tests/test_pyspark_24_to_30.py
@@ -148,7 +148,7 @@ str_len = pandas_udf(lambda s: s.str.len(), IntegerType())
 """
     modified_code = rewrite(given_code, PandasUdfUsageTransformer())
     expected_code = """\
-import pyspark.sql.functions.pandas_udf  # PY24-30-003: PySpark 3.0 requires a PyArrow version of 0.12.1 or higher to use pandas_udf
+import pyspark.sql.functions.pandas_udf  # PY24-30-003: PySpark 3.0 requires PyArrow version 0.12.1 or higher to use pandas_udf
 import pyspark.sql.functions.PandasUDFType
 
 from pyspark.sql.types import IntegerType, StringType
@@ -167,7 +167,7 @@ str_len = pandas_udf(lambda s: s.str.len(), IntegerType())
 """
     modified_code = rewrite(given_code, PandasUdfUsageTransformer())
     expected_code = """\
-from pyspark.sql.functions import pandas_udf, PandasUDFType  # PY24-30-003: PySpark 3.0 requires a PyArrow version of 0.12.1 or higher to use pandas_udf
+from pyspark.sql.functions import pandas_udf, PandasUDFType  # PY24-30-003: PySpark 3.0 requires PyArrow version 0.12.1 or higher to use pandas_udf
 from pyspark.sql.types import IntegerType, StringType
 
 str_len = pandas_udf(lambda s: s.str.len(), IntegerType())

--- a/pysparkler/tests/test_pyspark_24_to_30.py
+++ b/pysparkler/tests/test_pyspark_24_to_30.py
@@ -220,3 +220,40 @@ df = spark.createDataFrame(pdf)
 result_pdf = df.select("*").toPandas()
 """
     assert modified_code == expected_code
+
+
+def test_writes_comment_when_spark_sql_execution_arrow_enabled_in_session_builder():
+    given_code = """\
+import numpy as np
+import pandas as pd
+
+spark = (
+    SparkSession
+    .builder
+    .appName("Your App Name")
+    .config("spark.some.config.option1", "some-value")
+    .config("spark.sql.execution.arrow.enabled", "true")
+    .getOrCreate())
+
+pdf = pd.DataFrame(np.random.rand(100, 3))
+df = spark.createDataFrame(pdf)
+result_pdf = df.select("*").toPandas()
+"""
+    modified_code = rewrite(given_code, PyArrowEnabledCommentWriter())
+    expected_code = """\
+import numpy as np
+import pandas as pd
+
+spark = (
+    SparkSession
+    .builder
+    .appName("Your App Name")
+    .config("spark.some.config.option1", "some-value")
+    .config("spark.sql.execution.arrow.enabled", "true")
+    .getOrCreate())  # PY24-30-004: PySpark 3.0 requires PyArrow version 0.12.1 or higher when spark.sql.execution.arrow.enabled is set to true
+
+pdf = pd.DataFrame(np.random.rand(100, 3))
+df = spark.createDataFrame(pdf)
+result_pdf = df.select("*").toPandas()
+"""
+    assert modified_code == expected_code

--- a/pysparkler/tests/test_pyspark_24_to_30.py
+++ b/pysparkler/tests/test_pyspark_24_to_30.py
@@ -18,6 +18,7 @@
 
 from pysparkler.pyspark_24_to_30 import (
     CreateDataFrameVerifySchemaCommentWriter,
+    MlParamMixinsSetterCommentWriter,
     PandasConvertToArrowArraySafelyCommentWriter,
     PandasUdfUsageTransformer,
     PyArrowEnabledCommentWriter,
@@ -358,3 +359,14 @@ print(rdd.collect())
 """
     modified_code = rewrite(given_code, RowFieldNamesNotSortedCommentWriter())
     assert modified_code == given_code
+
+
+def test_writes_comment_when_pyspark_ml_param_shared_is_used_in_from_import():
+    given_code = """\
+from pyspark.ml.param.shared import *
+"""
+    modified_code = rewrite(given_code, MlParamMixinsSetterCommentWriter())
+    expected_code = """\
+from pyspark.ml.param.shared import *  # PY24-30-008: In Spark 3.0, pyspark.ml.param.shared.Has* mixins do not provide any set*(self, value) setter methods anymore, use the respective self.set(self.*, value) instead.
+"""
+    assert modified_code == expected_code

--- a/pysparkler/tests/test_pyspark_24_to_30.py
+++ b/pysparkler/tests/test_pyspark_24_to_30.py
@@ -1,0 +1,99 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#  #
+#    http://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+
+from tests.conftest import rewrite
+
+from pysparkler.pyspark_24_to_30 import RequiredPandasVersionCommentWriter
+
+
+def test_adds_required_pandas_version_comment_to_import_statements_without_alias():
+    given_code = """
+import pandas
+import pyspark
+"""
+    modified_code = rewrite(given_code, RequiredPandasVersionCommentWriter())
+    expected_code = """
+import pandas  # PY24-30-001: PySpark 3.0 requires pandas version 0.23.2 or higher
+import pyspark
+"""
+    assert modified_code == expected_code
+
+
+def test_adds_required_pandas_version_comment_to_import_statements_with_alias():
+    given_code = """
+import pandas as pd
+import pyspark
+"""
+    modified_code = rewrite(given_code, RequiredPandasVersionCommentWriter())
+    expected_code = """
+import pandas as pd  # PY24-30-001: PySpark 3.0 requires pandas version 0.23.2 or higher
+import pyspark
+"""
+    assert modified_code == expected_code
+
+
+def test_adds_required_pandas_version_comment_to_from_import_statements_without_alias():
+    given_code = """
+from pandas import DataFrame
+import pyspark
+"""
+    modified_code = rewrite(given_code, RequiredPandasVersionCommentWriter())
+    expected_code = """
+from pandas import DataFrame  # PY24-30-001: PySpark 3.0 requires pandas version 0.23.2 or higher
+import pyspark
+"""
+    assert modified_code == expected_code
+
+
+def test_adds_required_pandas_version_comment_to_from_import_statements_with_alias():
+    given_code = """
+from pandas import DataFrame as df
+import pyspark
+"""
+    modified_code = rewrite(given_code, RequiredPandasVersionCommentWriter())
+    expected_code = """
+from pandas import DataFrame as df  # PY24-30-001: PySpark 3.0 requires pandas version 0.23.2 or higher
+import pyspark
+"""
+    assert modified_code == expected_code
+
+
+def test_required_pandas_version_comment_idempotency():
+    given_code = """
+import pandas as pd # PY24-30-001: An existing comment added by this transformer
+import pyspark
+"""
+    modified_code = rewrite(given_code, RequiredPandasVersionCommentWriter())
+    expected_code = """
+import pandas as pd # PY24-30-001: An existing comment added by this transformer
+import pyspark
+"""
+    assert modified_code == expected_code
+
+
+def test_does_not_overwrite_an_exising_user_comment():
+    given_code = """
+import pandas as pd # An existing comment
+import pyspark
+"""
+    modified_code = rewrite(given_code, RequiredPandasVersionCommentWriter())
+    expected_code = """
+import pandas as pd # An existing comment  # PY24-30-001: PySpark 3.0 requires pandas version 0.23.2 or higher
+import pyspark
+"""
+    assert modified_code == expected_code

--- a/pysparkler/tests/test_pyspark_24_to_30.py
+++ b/pysparkler/tests/test_pyspark_24_to_30.py
@@ -17,6 +17,7 @@
 #
 
 from pysparkler.pyspark_24_to_30 import (
+    PandasUdfUsageTransformer,
     RequiredPandasVersionCommentWriter,
     ToPandasUsageTransformer,
 )
@@ -113,8 +114,6 @@ data = [("James","","Smith","36636","M",60000),
 
 columns = ["first_name","middle_name","last_name","dob","gender","salary"]
 pysparkDF = spark.createDataFrame(data = data, schema = columns)
-pysparkDF.printSchema()
-pysparkDF.show(truncate=False)
 
 pandasDF = pysparkDF.toPandas()
 print(pandasDF)
@@ -131,10 +130,46 @@ data = [("James","","Smith","36636","M",60000),
 
 columns = ["first_name","middle_name","last_name","dob","gender","salary"]
 pysparkDF = spark.createDataFrame(data = data, schema = columns)
-pysparkDF.printSchema()
-pysparkDF.show(truncate=False)
 
 pandasDF = pysparkDF.toPandas()  # PY24-30-002: PySpark 3.0 requires a pandas version of 0.23.2 or higher to use toPandas()
 print(pandasDF)
+"""
+    assert modified_code == expected_code
+
+
+def test_writes_comment_when_pandas_udf_is_used_in_an_import():
+    given_code = """\
+import pyspark.sql.functions.pandas_udf
+import pyspark.sql.functions.PandasUDFType
+
+from pyspark.sql.types import IntegerType, StringType
+
+str_len = pandas_udf(lambda s: s.str.len(), IntegerType())
+"""
+    modified_code = rewrite(given_code, PandasUdfUsageTransformer())
+    expected_code = """\
+import pyspark.sql.functions.pandas_udf  # PY24-30-003: PySpark 3.0 requires a PyArrow version of 0.12.1 or higher to use pandas_udf
+import pyspark.sql.functions.PandasUDFType
+
+from pyspark.sql.types import IntegerType, StringType
+
+str_len = pandas_udf(lambda s: s.str.len(), IntegerType())
+"""
+    assert modified_code == expected_code
+
+
+def test_writes_comment_when_pandas_udf_is_used_in_a_from_import():
+    given_code = """\
+from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.types import IntegerType, StringType
+
+str_len = pandas_udf(lambda s: s.str.len(), IntegerType())
+"""
+    modified_code = rewrite(given_code, PandasUdfUsageTransformer())
+    expected_code = """\
+from pyspark.sql.functions import pandas_udf, PandasUDFType  # PY24-30-003: PySpark 3.0 requires a PyArrow version of 0.12.1 or higher to use pandas_udf
+from pyspark.sql.types import IntegerType, StringType
+
+str_len = pandas_udf(lambda s: s.str.len(), IntegerType())
 """
     assert modified_code == expected_code

--- a/pysparkler/tests/test_pyspark_24_to_30.py
+++ b/pysparkler/tests/test_pyspark_24_to_30.py
@@ -17,6 +17,7 @@
 #
 
 from pysparkler.pyspark_24_to_30 import (
+    CreateDataFrameVerifySchemaCommentWriter,
     PandasConvertToArrowArraySafelyCommentWriter,
     PandasUdfUsageTransformer,
     PyArrowEnabledCommentWriter,
@@ -279,5 +280,40 @@ spark.conf.set("spark.sql.execution.arrow.pyspark.enabled", "true")  # PY24-30-0
 pdf = pd.DataFrame(np.random.rand(100, 3))
 df = spark.createDataFrame(pdf)
 result_pdf = df.select("*").toPandas()
+"""
+    assert modified_code == expected_code
+
+
+def test_writes_comment_when_verify_schema_set_to_true_while_creating_data_frame():
+    given_code = """\
+import pyspark
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder.appName('example').getOrCreate()
+
+data = [("James","","Smith","36636","M",60000),
+        ("Jen","Mary","Brown","","F",0)]
+
+columns = ["first_name","middle_name","last_name","dob","gender","salary"]
+pysparkDF = spark.createDataFrame(data = data, schema = columns, verifySchema = True)
+
+pandasDF = pysparkDF.toPandas()
+print(pandasDF)
+"""
+    modified_code = rewrite(given_code, CreateDataFrameVerifySchemaCommentWriter())
+    expected_code = """\
+import pyspark
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder.appName('example').getOrCreate()
+
+data = [("James","","Smith","36636","M",60000),
+        ("Jen","Mary","Brown","","F",0)]
+
+columns = ["first_name","middle_name","last_name","dob","gender","salary"]
+pysparkDF = spark.createDataFrame(data = data, schema = columns, verifySchema = True)  # PY24-30-006: Setting verifySchema to True validates LongType as well in PySpark 3.0. Previously, LongType was not verified and resulted in None in case the value overflows.
+
+pandasDF = pysparkDF.toPandas()
+print(pandasDF)
 """
     assert modified_code == expected_code


### PR DESCRIPTION
Ref: https://spark.apache.org/docs/latest/api/python/migration_guide/pyspark_2.4_to_3.0.html

Following every guideline from the above link.