### PR TITLE
PySparkler: Fix PySparkler distribution directory for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,5 @@ jobs:
       - name: Publish PySparkler Package on PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYSPARKLER_PYPI_API_TOKEN }} # Need Holden to add this as a repo secret
+          packages-dir: pysparkler/dist/
+          password: ${{ secrets.PYSPARKLER_PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ project/metals.sbt
 **/venv/*
 *.iml
 **/dist/*
+**/__pycache__/*


### PR DESCRIPTION
Fix PySparkler distribution directory for publishing to PyPI on release.