### PR TITLE
PySparkler: Sort Dataframe Row fields by name alphabetically

### DIFF
--- a/pysparkler/pysparkler/pyspark_24_to_30.py
+++ b/pysparkler/pysparkler/pyspark_24_to_30.py
@@ -269,7 +269,7 @@ class RowFieldNamesNotSortedCommentWriter(StatementLineCommentWriter):
     ):
         super().__init__(
             transformer_id="PY24-30-007",
-            comment=f"As of Spark {pyspark_version}, Row field names are no longer sorted alphabetically when constructing with named arguments.",
+            comment=f"Sorting Row fields by name alphabetically since as of Spark {pyspark_version}, they are no longer when constructed with named arguments.",
         )
 
     def visit_Call(self, node: cst.Call) -> None:
@@ -286,6 +286,18 @@ class RowFieldNamesNotSortedCommentWriter(StatementLineCommentWriter):
             ),
         ):
             self.match_found = True
+
+    def leave_Call(self, original_node: cst.Call, updated_node: cst.Call) -> cst.Call:
+        """Sort Dataframe Row fields by name alphabetically when constructed with named arguments for backwards
+        compatibility"""
+        if self.match_found:
+            row_fields = sorted(
+                updated_node.args,
+                key=lambda arg: arg.keyword.value,
+            )
+            return updated_node.with_changes(args=row_fields)
+        else:
+            return original_node
 
 
 class MlParamMixinsSetterCommentWriter(StatementLineCommentWriter):

--- a/pysparkler/tests/test_pyspark_24_to_30.py
+++ b/pysparkler/tests/test_pyspark_24_to_30.py
@@ -337,8 +337,8 @@ print(rdd.collect())
 from pyspark.sql import SparkSession, Row
 spark = SparkSession.builder.appName('example').getOrCreate()
 
-data = [Row(name="James,,Smith",lang=["Java","Scala","C++"],state="CA"),
-    Row(name="Robert,,Williams",lang=["CSharp","VB"],state="NV")]  # PY24-30-007: As of Spark 3.0, Row field names are no longer sorted alphabetically when constructing with named arguments.
+data = [Row(lang=["Java","Scala","C++"],name="James,,Smith",state="CA"),
+    Row(lang=["CSharp","VB"],name="Robert,,Williams",state="NV")]  # PY24-30-007: Sorting Row fields by name alphabetically since as of Spark 3.0, they are no longer when constructed with named arguments.
 
 rdd=spark.sparkContext.parallelize(data)
 print(rdd.collect())


### PR DESCRIPTION
Sort Dataframe Row fields by name alphabetically when constructed with named arguments for backwards compatibility.