### PR TITLE
Add cast extract seconds rule to sqlfluff plugin

### DIFF
--- a/sql/test/rules/test_cases/SPARK_SQL_EXTRACT_SECOND.yml
+++ b/sql/test/rules/test_cases/SPARK_SQL_EXTRACT_SECOND.yml
@@ -1,0 +1,10 @@
+rule: SPARKSQL_L004
+
+extract_second:
+  configs:
+    core:
+      dialect: sparksql
+  fail_str: |
+    select extract(second from to_timestamp('2019-09-20 10:10:10.1'))
+  fix_str: |
+    select cast(extract(second from to_timestamp('2019-09-20 10:10:10.1')) as int)


### PR DESCRIPTION
This change adds a new rule `SPARKSQL_L004` that does the following: 

* All instances of `extract(seconds...)` will be converted to `cast(extract(seconds ..) as int)` 

This is due to the following change in the migration guide: 

> Since Spark 3.0, when using EXTRACT expression to extract the second field from date/timestamp values, the result will be a DecimalType(8, 6) value with 2 digits for second part, and 6 digits for the fractional part with microsecond precision. e.g. extract(second from to_timestamp('2019-09-20 10:10:10.1')) results 10.100000. In Spark version 2.4 and earlier, it returns an IntegerType value and the result for the former example is 10.
