### PR TITLE
PySparkler: Release PySparkler v0.8.0

### DIFF
--- a/pysparkler/poetry.lock
+++ b/pysparkler/poetry.lock
@@ -829,20 +829,18 @@ typing-extensions = "*"
 
 [[package]]
 name = "sqlfluff-plugin-sparksql-upgrade"
-version = "0.0.0"
+version = "0.1.0"
 description = "SQLFluff rules to help migrate your Spark SQL from 2.X to 3.X"
 category = "main"
 optional = false
 python-versions = "*"
-files = []
-develop = false
+files = [
+    {file = "sqlfluff-plugin-sparksql-upgrade-0.1.0.tar.gz", hash = "sha256:3204604b15aeef9ff9ca0b3287d6f22129ef571c2a666a0a513392880204d028"},
+    {file = "sqlfluff_plugin_sparksql_upgrade-0.1.0-py3-none-any.whl", hash = "sha256:7c85c21af9b418021cad53427de05ef1df570b3cb74435e4a9b6fc53f46d8160"},
+]
 
 [package.dependencies]
 sqlfluff = ">=1.0.0"
-
-[package.source]
-type = "directory"
-url = "../sql"
 
 [[package]]
 name = "tblib"
@@ -969,4 +967,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "3099d2a7d65e0caadd21d1d3bfc65f214437c08154cba79076a994aff27cdc10"
+content-hash = "0c7b9e2e2b2be7f575a95fdef123403217e8b54c2aa74c36a0b2c5ebe740942d"

--- a/pysparkler/pyproject.toml
+++ b/pysparkler/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysparkler"
-version = "0.8.dev"
+version = "0.8.0"
 description = "A tool that upgrades your PySpark scripts to the latest Spark version as per Spark migration Guideline"
 authors = ["Dhruv Pratap <dhruv.pratap@gmail.com>"]
 readme = "README.md"

--- a/pysparkler/pyproject.toml
+++ b/pysparkler/pyproject.toml
@@ -19,7 +19,7 @@ click = "^8.1.3"
 rich = "^13.3.3"
 nbformat = "^5.8.0"
 sqlfluff = "^1.0.0"
-sqlfluff-plugin-sparksql-upgrade = {path = "../sql"}
+sqlfluff-plugin-sparksql-upgrade = "^0.1.0"
 
 
 [tool.poetry.group.test.dependencies]

--- a/sql/setup.py
+++ b/sql/setup.py
@@ -9,11 +9,12 @@ setup(
     name="sqlfluff-plugin-{plugin_logical_name}".format(
         plugin_logical_name=PLUGIN_LOGICAL_NAME
     ),
-    version="",
+    version="0.1.0",
     author="Holden Karau",
     author_email="holden@pigscanfly.ca",
     url="https://github.com/holdenk/spark-upgrade",
     description="SQLFluff rules to help migrate your Spark SQL from 2.X to 3.X",
+    long_description="SQLFluff rules to help migrate your Spark SQL from 2.X to 3.X",
     test_requires=["nose", "coverage", "unittest2"],
     license="../LICENSE",
     include_package_data=True,


### PR DESCRIPTION
* Make sqlfluff-plugin-sparksql-upgrade dependency as a PyPI dependency instead of a local dependency.