### PR TITLE
Add PySpark 3.5→4.0 pandas-on-Spark API removal detection rules

### DIFF
--- a/pysparkler/README.md
+++ b/pysparkler/README.md
@@ -81,6 +81,16 @@ to upgrade your PySpark scripts. In the latest stable version it supports the fo
   removed pandas-on-spark APIs, raised minimum dependency versions). Because these are not safe to rewrite
   automatically in a dynamically-typed language, the 4.x rules mostly emit **code hints** rather than code
   transformations. Review each hint and apply the suggested change where it is relevant.
+- The `3.5 → 4.0` transition (`PY35-40-*`) covers the full set of pandas-on-spark removals from the migration
+  guide: removed methods (`iteritems`, `append`, `mad`, `to_spark_io`, `get_dtype_counts`, the `.koalas`
+  accessor, `is_monotonic`, `week`/`weekofyear`, GroupBy `backfill`/`pad`, the `Int64Index`/`Float64Index`
+  classes, and several removed `Index` APIs) and removed keyword parameters (`na_sentinel`, Categorical/
+  CategoricalIndex `inplace`, `date_range(closed=...)`, `between_time(include_start=/include_end=)`,
+  `Series.between(inclusive=True/False)`, `plot(sort_columns=...)`, `to_latex(col_space=...)`,
+  `to_excel(encoding=/verbose=)`, `read_csv`/`read_excel(squeeze=/mangle_dupe_cols=/convert_float=)`,
+  `info(null_counts=...)`), plus the removed `assertPandasOnSparkEqual` testing helper. Because the tool is
+  syntactic (no type information), hints for common method names such as `.append` and `.pad` are worded
+  conditionally — verify the receiver is a pandas-on-spark object before applying the change.
 - PySparkler applies every implemented rule on each run; the `from_pyspark` / `to_pyspark` arguments do not
   currently scope which rules run. The `3.3 → 3.4` and `3.4 → 3.5` steps have no rules yet, so those
   intermediate hints are simply absent (not filtered out by a version range).

--- a/pysparkler/README.md
+++ b/pysparkler/README.md
@@ -87,8 +87,9 @@ to upgrade your PySpark scripts. In the latest stable version it supports the fo
   classes, and several removed `Index` APIs) and removed keyword parameters (`na_sentinel`, Categorical/
   CategoricalIndex `inplace`, `date_range(closed=...)`, `between_time(include_start=/include_end=)`,
   `Series.between(inclusive=True/False)`, `plot(sort_columns=...)`, `to_latex(col_space=...)`,
-  `to_excel(encoding=/verbose=)`, `read_csv`/`read_excel(squeeze=/mangle_dupe_cols=/convert_float=)`,
-  `info(null_counts=...)`), plus the removed `assertPandasOnSparkEqual` testing helper. Because the tool is
+  `to_excel(encoding=/verbose=)`, `read_csv`/`read_excel(squeeze=/mangle_dupe_cols=)`,
+  `read_excel(convert_float=...)`, `info(null_counts=...)`), plus the removed `assertPandasOnSparkEqual`
+  testing helper. Because the tool is
   syntactic (no type information), hints for common method names such as `.append` and `.pad` are worded
   conditionally — verify the receiver is a pandas-on-spark object before applying the change.
 - PySparkler applies every implemented rule on each run; the `from_pyspark` / `to_pyspark` arguments do not

--- a/pysparkler/pysparkler/pyspark_35_to_40.py
+++ b/pysparkler/pysparkler/pyspark_35_to_40.py
@@ -288,6 +288,546 @@ required.",
         )
 
 
+class PandasAppendRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, DataFrame.append and Series.append have been removed from pandas API on Spark, use ps.concat
+    instead.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-011",
+            comment=f"As of PySpark {pyspark_version}, if this is a pandas-on-Spark DataFrame or Series then \
+.append has been removed, use ps.concat instead.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if the removed append method is being called"""
+        if m.matches(node, m.Call(func=m.Attribute(attr=m.Name("append")))):
+            self.match_found = True
+
+
+class PandasMadRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, DataFrame.mad and Series.mad have been removed from pandas API on Spark."""
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-012",
+            comment=f"As of PySpark {pyspark_version}, if this is a pandas-on-Spark DataFrame or Series then \
+.mad has been removed; compute the mean absolute deviation manually instead.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if the removed mad method is being called"""
+        if m.matches(node, m.Call(func=m.Attribute(attr=m.Name("mad")))):
+            self.match_found = True
+
+
+class PandasToSparkIoRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, DataFrame.to_spark_io has been removed from pandas API on Spark, use DataFrame.spark.to_spark_io
+    instead.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-013",
+            comment=f"As of PySpark {pyspark_version}, DataFrame.to_spark_io has been removed from pandas API on \
+Spark, use DataFrame.spark.to_spark_io instead.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if the removed to_spark_io method is being called"""
+        if m.matches(node, m.Call(func=m.Attribute(attr=m.Name("to_spark_io")))):
+            self.match_found = True
+
+
+class PandasGetDtypeCountsRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, DataFrame.get_dtype_counts has been removed from pandas API on Spark, use
+    DataFrame.dtypes.value_counts() instead.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-014",
+            comment=f"As of PySpark {pyspark_version}, DataFrame.get_dtype_counts has been removed from pandas API \
+on Spark, use DataFrame.dtypes.value_counts() instead.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if the removed get_dtype_counts method is being called"""
+        if m.matches(node, m.Call(func=m.Attribute(attr=m.Name("get_dtype_counts")))):
+            self.match_found = True
+
+
+class PandasKoalasAccessorRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, DataFrame.koalas has been removed from pandas API on Spark, use DataFrame.pandas_on_spark
+    instead.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-015",
+            comment=f"As of PySpark {pyspark_version}, the .koalas accessor has been removed from pandas API on \
+Spark, use .pandas_on_spark instead.",
+        )
+
+    def visit_Attribute(self, node: cst.Attribute) -> None:
+        """Check if the removed koalas accessor is being used"""
+        if m.matches(node, m.Attribute(attr=m.Name("koalas"))):
+            self.match_found = True
+
+
+class PandasIndexApisRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, Index.asi8, Index.is_type_compatible and Index.is_all_dates have been removed from pandas API on
+    Spark.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-016",
+            comment=f"As of PySpark {pyspark_version}, Index.asi8 (use Index.astype instead), \
+Index.is_type_compatible (use Index.isin instead) and Index.is_all_dates have been removed from pandas API on Spark.",
+        )
+
+    def visit_Attribute(self, node: cst.Attribute) -> None:
+        """Check if the removed asi8 / is_all_dates properties are being accessed"""
+        if m.matches(
+            node, m.Attribute(attr=m.OneOf(m.Name("asi8"), m.Name("is_all_dates")))
+        ):
+            self.match_found = True
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if the removed is_type_compatible method is being called"""
+        if m.matches(node, m.Call(func=m.Attribute(attr=m.Name("is_type_compatible")))):
+            self.match_found = True
+
+
+class PandasIsMonotonicRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, Series.is_monotonic and Index.is_monotonic have been removed from pandas API on Spark, use
+    is_monotonic_increasing instead.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-017",
+            comment=f"As of PySpark {pyspark_version}, Series.is_monotonic and Index.is_monotonic have been removed \
+from pandas API on Spark, use is_monotonic_increasing instead.",
+        )
+
+    def visit_Attribute(self, node: cst.Attribute) -> None:
+        """Check if the removed is_monotonic property is being accessed"""
+        if m.matches(node, m.Attribute(attr=m.Name("is_monotonic"))):
+            self.match_found = True
+
+
+class PandasWeekOfYearRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, DatetimeIndex.week/weekofyear and Series.dt.week/weekofyear have been removed from pandas API on
+    Spark, use isocalendar().week instead.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-018",
+            comment=f"As of PySpark {pyspark_version}, if this is a pandas-on-Spark DatetimeIndex or Series.dt then \
+.week and .weekofyear have been removed, use .isocalendar().week instead.",
+        )
+
+    def visit_Attribute(self, node: cst.Attribute) -> None:
+        """Check if the removed week / weekofyear properties are being accessed"""
+        if m.matches(
+            node, m.Attribute(attr=m.OneOf(m.Name("week"), m.Name("weekofyear")))
+        ):
+            # Skip the already-migrated ``...isocalendar().week`` form.
+            if m.matches(
+                node.value, m.Call(func=m.Attribute(attr=m.Name("isocalendar")))
+            ):
+                return
+            self.match_found = True
+
+
+class PandasGroupByBackfillPadRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, DataFrameGroupBy.backfill and DataFrameGroupBy.pad have been removed from pandas API on Spark, use
+    bfill and ffill instead.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-019",
+            comment=f"As of PySpark {pyspark_version}, if this is a pandas-on-Spark GroupBy then .backfill (use \
+.bfill instead) and .pad (use .ffill instead) have been removed.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if the removed backfill / pad GroupBy methods are being called"""
+        if m.matches(
+            node,
+            m.Call(func=m.Attribute(attr=m.OneOf(m.Name("backfill"), m.Name("pad")))),
+        ):
+            self.match_found = True
+
+
+class PandasCategoricalInplaceRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, the inplace parameter of the Categorical / CategoricalIndex category methods has been removed from
+    pandas API on Spark.
+    """
+
+    _category_methods = (
+        "add_categories",
+        "remove_categories",
+        "remove_unused_categories",
+        "set_categories",
+        "rename_categories",
+        "reorder_categories",
+        "as_ordered",
+        "as_unordered",
+    )
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-020",
+            comment=f"As of PySpark {pyspark_version}, the inplace parameter of the Categorical and CategoricalIndex \
+category methods has been removed from pandas API on Spark; assign the returned value instead.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if a category method is called with the removed inplace keyword argument"""
+        if m.matches(
+            node,
+            m.Call(
+                func=m.Attribute(
+                    attr=m.OneOf(*[m.Name(name) for name in self._category_methods])
+                ),
+                args=[
+                    m.ZeroOrMore(),
+                    m.Arg(keyword=m.Name("inplace")),
+                    m.ZeroOrMore(),
+                ],
+            ),
+        ):
+            self.match_found = True
+
+
+class PandasDateRangeClosedRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, the closed parameter from ps.date_range has been removed from pandas API on Spark."""
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-021",
+            comment=f"As of PySpark {pyspark_version}, the closed parameter of ps.date_range has been removed from \
+pandas API on Spark, use the inclusive parameter instead.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if date_range is called with the removed closed keyword argument"""
+        if m.matches(
+            node,
+            m.Call(
+                func=m.OneOf(
+                    m.Name("date_range"), m.Attribute(attr=m.Name("date_range"))
+                ),
+                args=[
+                    m.ZeroOrMore(),
+                    m.Arg(keyword=m.Name("closed")),
+                    m.ZeroOrMore(),
+                ],
+            ),
+        ):
+            self.match_found = True
+
+
+class PandasBetweenTimeInclusiveRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, the include_start and include_end parameters from DataFrame.between_time and Series.between_time
+    have been removed from pandas API on Spark, use inclusive instead.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-022",
+            comment=f"As of PySpark {pyspark_version}, the include_start and include_end parameters of between_time \
+have been removed from pandas API on Spark, use the inclusive parameter instead.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if between_time is called with the removed include_start / include_end keyword arguments"""
+        if m.matches(
+            node,
+            m.Call(
+                func=m.Attribute(attr=m.Name("between_time")),
+                args=[
+                    m.ZeroOrMore(),
+                    m.Arg(
+                        keyword=m.OneOf(m.Name("include_start"), m.Name("include_end"))
+                    ),
+                    m.ZeroOrMore(),
+                ],
+            ),
+        ):
+            self.match_found = True
+
+
+class PandasSeriesBetweenBooleanInclusiveRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, passing True or False to the inclusive parameter of Series.between has been removed from pandas
+    API on Spark, use "both" or "neither" instead respectively.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-023",
+            comment=f'As of PySpark {pyspark_version}, passing True or False to the inclusive parameter of \
+Series.between has been removed from pandas API on Spark, use "both" or "neither" instead respectively.',
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if between is called with a boolean inclusive keyword argument"""
+        if m.matches(
+            node,
+            m.Call(
+                func=m.Attribute(attr=m.Name("between")),
+                args=[
+                    m.ZeroOrMore(),
+                    m.Arg(
+                        keyword=m.Name("inclusive"),
+                        value=m.OneOf(m.Name("True"), m.Name("False")),
+                    ),
+                    m.ZeroOrMore(),
+                ],
+            ),
+        ):
+            self.match_found = True
+
+
+class PandasPlotSortColumnsRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, the sort_columns parameter from DataFrame.plot and Series.plot has been removed from pandas API on
+    Spark.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-024",
+            comment=f"As of PySpark {pyspark_version}, the sort_columns parameter of DataFrame.plot and Series.plot \
+has been removed from pandas API on Spark.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if a plot call uses the removed sort_columns keyword argument"""
+        if m.matches(
+            node,
+            m.Call(
+                args=[
+                    m.ZeroOrMore(),
+                    m.Arg(keyword=m.Name("sort_columns")),
+                    m.ZeroOrMore(),
+                ],
+            ),
+        ):
+            self.match_found = True
+
+
+class PandasToLatexColSpaceRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, the col_space parameter from DataFrame.to_latex and Series.to_latex has been removed from pandas
+    API on Spark.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-025",
+            comment=f"As of PySpark {pyspark_version}, the col_space parameter of to_latex has been removed from \
+pandas API on Spark.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if to_latex is called with the removed col_space keyword argument"""
+        if m.matches(
+            node,
+            m.Call(
+                func=m.Attribute(attr=m.Name("to_latex")),
+                args=[
+                    m.ZeroOrMore(),
+                    m.Arg(keyword=m.Name("col_space")),
+                    m.ZeroOrMore(),
+                ],
+            ),
+        ):
+            self.match_found = True
+
+
+class PandasToExcelParamsRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, the encoding and verbose parameters from DataFrame.to_excel and Series.to_excel have been removed
+    from pandas API on Spark.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-026",
+            comment=f"As of PySpark {pyspark_version}, the encoding and verbose parameters of to_excel have been \
+removed from pandas API on Spark.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if to_excel is called with the removed encoding / verbose keyword arguments"""
+        if m.matches(
+            node,
+            m.Call(
+                func=m.Attribute(attr=m.Name("to_excel")),
+                args=[
+                    m.ZeroOrMore(),
+                    m.Arg(keyword=m.OneOf(m.Name("encoding"), m.Name("verbose"))),
+                    m.ZeroOrMore(),
+                ],
+            ),
+        ):
+            self.match_found = True
+
+
+class PandasReadCsvExcelParamsRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, the squeeze and mangle_dupe_cols parameters from ps.read_csv / ps.read_excel and the
+    convert_float parameter from ps.read_excel have been removed from pandas API on Spark.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-027",
+            comment=f"As of PySpark {pyspark_version}, the squeeze, mangle_dupe_cols and convert_float parameters of \
+ps.read_csv / ps.read_excel have been removed from pandas API on Spark.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if read_csv / read_excel is called with a removed keyword argument"""
+        if m.matches(
+            node,
+            m.Call(
+                func=m.OneOf(
+                    m.Name("read_csv"),
+                    m.Name("read_excel"),
+                    m.Attribute(attr=m.Name("read_csv")),
+                    m.Attribute(attr=m.Name("read_excel")),
+                ),
+                args=[
+                    m.ZeroOrMore(),
+                    m.Arg(
+                        keyword=m.OneOf(
+                            m.Name("squeeze"),
+                            m.Name("mangle_dupe_cols"),
+                            m.Name("convert_float"),
+                        )
+                    ),
+                    m.ZeroOrMore(),
+                ],
+            ),
+        ):
+            self.match_found = True
+
+
+class PandasInfoNullCountsRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, the null_counts parameter from DataFrame.info has been removed from pandas API on Spark, use
+    show_counts instead.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-028",
+            comment=f"As of PySpark {pyspark_version}, the null_counts parameter of DataFrame.info has been removed \
+from pandas API on Spark, use show_counts instead.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if info is called with the removed null_counts keyword argument"""
+        if m.matches(
+            node,
+            m.Call(
+                func=m.Attribute(attr=m.Name("info")),
+                args=[
+                    m.ZeroOrMore(),
+                    m.Arg(keyword=m.Name("null_counts")),
+                    m.ZeroOrMore(),
+                ],
+            ),
+        ):
+            self.match_found = True
+
+
+class AssertPandasOnSparkEqualRemoved(StatementLineCommentWriter):
+    """In Spark 4.0, pyspark.testing.assertPandasOnSparkEqual has been removed, use
+    pyspark.pandas.testing.assert_frame_equal instead.
+    """
+
+    def __init__(
+        self,
+        pyspark_version: str = "4.0",
+    ):
+        super().__init__(
+            transformer_id="PY35-40-029",
+            comment=f"As of PySpark {pyspark_version}, pyspark.testing.assertPandasOnSparkEqual has been removed, \
+use pyspark.pandas.testing.assert_frame_equal instead.",
+        )
+
+    def visit_Call(self, node: cst.Call) -> None:
+        """Check if the removed assertPandasOnSparkEqual function is being called"""
+        if m.matches(
+            node,
+            m.Call(
+                func=m.OneOf(
+                    m.Name("assertPandasOnSparkEqual"),
+                    m.Attribute(attr=m.Name("assertPandasOnSparkEqual")),
+                )
+            ),
+        ):
+            self.match_found = True
+
+
 def pyspark_35_to_40_transformers() -> list[cst.CSTTransformer]:
     """Return a list of transformers for PySpark 3.5 to 4.0 migration guide"""
     return [
@@ -301,4 +841,23 @@ def pyspark_35_to_40_transformers() -> list[cst.CSTTransformer]:
         SqlFunctionsStarImport(),
         FactorizeNaSentinelRenamed(),
         Python38SupportDropped(),
+        PandasAppendRemoved(),
+        PandasMadRemoved(),
+        PandasToSparkIoRemoved(),
+        PandasGetDtypeCountsRemoved(),
+        PandasKoalasAccessorRemoved(),
+        PandasIndexApisRemoved(),
+        PandasIsMonotonicRemoved(),
+        PandasWeekOfYearRemoved(),
+        PandasGroupByBackfillPadRemoved(),
+        PandasCategoricalInplaceRemoved(),
+        PandasDateRangeClosedRemoved(),
+        PandasBetweenTimeInclusiveRemoved(),
+        PandasSeriesBetweenBooleanInclusiveRemoved(),
+        PandasPlotSortColumnsRemoved(),
+        PandasToLatexColSpaceRemoved(),
+        PandasToExcelParamsRemoved(),
+        PandasReadCsvExcelParamsRemoved(),
+        PandasInfoNullCountsRemoved(),
+        AssertPandasOnSparkEqualRemoved(),
     ]

--- a/pysparkler/pysparkler/pyspark_35_to_40.py
+++ b/pysparkler/pysparkler/pyspark_35_to_40.py
@@ -616,21 +616,28 @@ Series.between has been removed from pandas API on Spark, use "both" or "neither
         )
 
     def visit_Call(self, node: cst.Call) -> None:
-        """Check if between is called with a boolean inclusive keyword argument"""
-        if m.matches(
-            node,
-            m.Call(
-                func=m.Attribute(attr=m.Name("between")),
-                args=[
-                    m.ZeroOrMore(),
-                    m.Arg(
-                        keyword=m.Name("inclusive"),
-                        value=m.OneOf(m.Name("True"), m.Name("False")),
-                    ),
-                    m.ZeroOrMore(),
-                ],
-            ),
-        ):
+        """Check if between is called with a boolean inclusive argument (keyword or third positional)"""
+        boolean = m.OneOf(m.Name("True"), m.Name("False"))
+        keyword_form = m.Call(
+            func=m.Attribute(attr=m.Name("between")),
+            args=[
+                m.ZeroOrMore(),
+                m.Arg(keyword=m.Name("inclusive"), value=boolean),
+                m.ZeroOrMore(),
+            ],
+        )
+        # Spark 3.5 also accepted ``inclusive`` as the third positional argument,
+        # e.g. ``series.between(1, 5, False)``.
+        positional_form = m.Call(
+            func=m.Attribute(attr=m.Name("between")),
+            args=[
+                m.Arg(keyword=None),
+                m.Arg(keyword=None),
+                m.Arg(keyword=None, value=boolean),
+                m.ZeroOrMore(),
+            ],
+        )
+        if m.matches(node, keyword_form) or m.matches(node, positional_form):
             self.match_found = True
 
 
@@ -654,6 +661,7 @@ has been removed from pandas API on Spark.",
         if m.matches(
             node,
             m.Call(
+                func=m.Attribute(attr=m.Name("plot")),
                 args=[
                     m.ZeroOrMore(),
                     m.Arg(keyword=m.Name("sort_columns")),

--- a/pysparkler/pysparkler/pyspark_35_to_40.py
+++ b/pysparkler/pysparkler/pyspark_35_to_40.py
@@ -745,34 +745,41 @@ class PandasReadCsvExcelParamsRemoved(StatementLineCommentWriter):
     ):
         super().__init__(
             transformer_id="PY35-40-027",
-            comment=f"As of PySpark {pyspark_version}, the squeeze, mangle_dupe_cols and convert_float parameters of \
-ps.read_csv / ps.read_excel have been removed from pandas API on Spark.",
+            comment=f"As of PySpark {pyspark_version}, the squeeze and mangle_dupe_cols parameters of ps.read_csv / \
+ps.read_excel, and the convert_float parameter of ps.read_excel, have been removed from pandas API on Spark.",
         )
 
     def visit_Call(self, node: cst.Call) -> None:
         """Check if read_csv / read_excel is called with a removed keyword argument"""
-        if m.matches(
-            node,
-            m.Call(
-                func=m.OneOf(
-                    m.Name("read_csv"),
-                    m.Name("read_excel"),
-                    m.Attribute(attr=m.Name("read_csv")),
-                    m.Attribute(attr=m.Name("read_excel")),
-                ),
-                args=[
-                    m.ZeroOrMore(),
-                    m.Arg(
-                        keyword=m.OneOf(
-                            m.Name("squeeze"),
-                            m.Name("mangle_dupe_cols"),
-                            m.Name("convert_float"),
-                        )
-                    ),
-                    m.ZeroOrMore(),
-                ],
-            ),
-        ):
+        read_csv_or_excel = m.OneOf(
+            m.Name("read_csv"),
+            m.Name("read_excel"),
+            m.Attribute(attr=m.Name("read_csv")),
+            m.Attribute(attr=m.Name("read_excel")),
+        )
+        read_excel = m.OneOf(
+            m.Name("read_excel"),
+            m.Attribute(attr=m.Name("read_excel")),
+        )
+        # squeeze and mangle_dupe_cols were removed from both read_csv and read_excel.
+        shared_params = m.Call(
+            func=read_csv_or_excel,
+            args=[
+                m.ZeroOrMore(),
+                m.Arg(keyword=m.OneOf(m.Name("squeeze"), m.Name("mangle_dupe_cols"))),
+                m.ZeroOrMore(),
+            ],
+        )
+        # convert_float was removed from read_excel only.
+        read_excel_only = m.Call(
+            func=read_excel,
+            args=[
+                m.ZeroOrMore(),
+                m.Arg(keyword=m.Name("convert_float")),
+                m.ZeroOrMore(),
+            ],
+        )
+        if m.matches(node, shared_params) or m.matches(node, read_excel_only):
             self.match_found = True
 
 

--- a/pysparkler/tests/test_pyspark_35_to_40.py
+++ b/pysparkler/tests/test_pyspark_35_to_40.py
@@ -416,9 +416,25 @@ mask = series.between(1, 5, inclusive=True)
     assert "# PY35-40-023:" in modified_code
 
 
+def test_adds_code_hint_when_between_uses_positional_boolean_inclusive():
+    given_code = """
+mask = series.between(1, 5, False)
+"""
+    modified_code = rewrite(given_code, PandasSeriesBetweenBooleanInclusiveRemoved())
+    assert "# PY35-40-023:" in modified_code
+
+
 def test_does_nothing_for_between_with_string_inclusive():
     given_code = """
 mask = series.between(1, 5, inclusive="both")
+"""
+    modified_code = rewrite(given_code, PandasSeriesBetweenBooleanInclusiveRemoved())
+    assert modified_code == given_code
+
+
+def test_does_nothing_for_between_with_positional_string_inclusive():
+    given_code = """
+mask = series.between(1, 5, "both")
 """
     modified_code = rewrite(given_code, PandasSeriesBetweenBooleanInclusiveRemoved())
     assert modified_code == given_code
@@ -430,6 +446,14 @@ df.plot(sort_columns=True)
 """
     modified_code = rewrite(given_code, PandasPlotSortColumnsRemoved())
     assert "# PY35-40-024:" in modified_code
+
+
+def test_does_nothing_for_sort_columns_on_non_plot_call():
+    given_code = """
+write_table(data, sort_columns=True)
+"""
+    modified_code = rewrite(given_code, PandasPlotSortColumnsRemoved())
+    assert modified_code == given_code
 
 
 def test_adds_code_hint_when_to_latex_uses_col_space():

--- a/pysparkler/tests/test_pyspark_35_to_40.py
+++ b/pysparkler/tests/test_pyspark_35_to_40.py
@@ -481,6 +481,15 @@ other = ps.read_excel("in.xlsx", convert_float=True)
     assert modified_code.count("# PY35-40-027:") == 2
 
 
+def test_does_nothing_for_read_csv_convert_float():
+    # convert_float was removed from read_excel only, not read_csv.
+    given_code = """
+df = ps.read_csv("in.csv", convert_float=True)
+"""
+    modified_code = rewrite(given_code, PandasReadCsvExcelParamsRemoved())
+    assert modified_code == given_code
+
+
 def test_adds_code_hint_when_info_uses_null_counts():
     given_code = """
 df.info(null_counts=True)

--- a/pysparkler/tests/test_pyspark_35_to_40.py
+++ b/pysparkler/tests/test_pyspark_35_to_40.py
@@ -18,10 +18,29 @@
 
 from pysparkler.pyspark_35_to_40 import (
     AnsiModeEnabledByDefault,
+    AssertPandasOnSparkEqualRemoved,
     FactorizeNaSentinelRenamed,
+    PandasAppendRemoved,
+    PandasBetweenTimeInclusiveRemoved,
+    PandasCategoricalInplaceRemoved,
+    PandasDateRangeClosedRemoved,
+    PandasGetDtypeCountsRemoved,
+    PandasGroupByBackfillPadRemoved,
+    PandasIndexApisRemoved,
     PandasIndexClassesRemoved,
+    PandasInfoNullCountsRemoved,
+    PandasIsMonotonicRemoved,
     PandasIteritemsRemoved,
+    PandasKoalasAccessorRemoved,
+    PandasMadRemoved,
+    PandasPlotSortColumnsRemoved,
+    PandasReadCsvExcelParamsRemoved,
+    PandasSeriesBetweenBooleanInclusiveRemoved,
+    PandasToExcelParamsRemoved,
     PandasToKoalasRemoved,
+    PandasToLatexColSpaceRemoved,
+    PandasToSparkIoRemoved,
+    PandasWeekOfYearRemoved,
     Python38SupportDropped,
     RequiredNumpyVersionCommentWriter,
     RequiredPandasVersionCommentWriter,
@@ -237,3 +256,227 @@ import numpy as np
 """
     modified_code = rewrite(given_code, Python38SupportDropped())
     assert modified_code == given_code
+
+
+def test_adds_code_hint_when_append_is_used():
+    given_code = """
+combined = df.append(other)
+"""
+    modified_code = rewrite(given_code, PandasAppendRemoved())
+    assert "# PY35-40-011:" in modified_code
+    assert "ps.concat" in modified_code
+
+
+def test_adds_code_hint_when_mad_is_used():
+    given_code = """
+result = df.mad()
+"""
+    modified_code = rewrite(given_code, PandasMadRemoved())
+    assert "# PY35-40-012:" in modified_code
+
+
+def test_adds_code_hint_when_to_spark_io_is_used():
+    given_code = """
+df.to_spark_io(path)
+"""
+    modified_code = rewrite(given_code, PandasToSparkIoRemoved())
+    expected_code = """
+df.to_spark_io(path)  # PY35-40-013: As of PySpark 4.0, DataFrame.to_spark_io has been removed from pandas API on Spark, use DataFrame.spark.to_spark_io instead.  # noqa: E501
+"""
+    assert modified_code == expected_code
+
+
+def test_adds_code_hint_when_get_dtype_counts_is_used():
+    given_code = """
+counts = df.get_dtype_counts()
+"""
+    modified_code = rewrite(given_code, PandasGetDtypeCountsRemoved())
+    expected_code = """
+counts = df.get_dtype_counts()  # PY35-40-014: As of PySpark 4.0, DataFrame.get_dtype_counts has been removed from pandas API on Spark, use DataFrame.dtypes.value_counts() instead.  # noqa: E501
+"""
+    assert modified_code == expected_code
+
+
+def test_adds_code_hint_when_koalas_accessor_is_used():
+    given_code = """
+frame = df.koalas.to_frame()
+"""
+    modified_code = rewrite(given_code, PandasKoalasAccessorRemoved())
+    assert "# PY35-40-015:" in modified_code
+    assert ".pandas_on_spark" in modified_code
+
+
+def test_does_nothing_for_pandas_on_spark_accessor():
+    given_code = """
+frame = df.pandas_on_spark.to_frame()
+"""
+    modified_code = rewrite(given_code, PandasKoalasAccessorRemoved())
+    assert modified_code == given_code
+
+
+def test_adds_code_hint_for_removed_index_apis():
+    given_code = """
+values = idx.asi8
+compatible = idx.is_type_compatible(other)
+all_dates = idx.is_all_dates
+"""
+    modified_code = rewrite(given_code, PandasIndexApisRemoved())
+    assert modified_code.count("# PY35-40-016:") == 3
+
+
+def test_adds_code_hint_when_is_monotonic_is_used():
+    given_code = """
+mono = series.is_monotonic
+"""
+    modified_code = rewrite(given_code, PandasIsMonotonicRemoved())
+    expected_code = """
+mono = series.is_monotonic  # PY35-40-017: As of PySpark 4.0, Series.is_monotonic and Index.is_monotonic have been removed from pandas API on Spark, use is_monotonic_increasing instead.  # noqa: E501
+"""
+    assert modified_code == expected_code
+
+
+def test_does_nothing_for_is_monotonic_increasing():
+    given_code = """
+mono = series.is_monotonic_increasing
+"""
+    modified_code = rewrite(given_code, PandasIsMonotonicRemoved())
+    assert modified_code == given_code
+
+
+def test_adds_code_hint_when_weekofyear_is_used():
+    given_code = """
+weeks = idx.weekofyear
+"""
+    modified_code = rewrite(given_code, PandasWeekOfYearRemoved())
+    assert "# PY35-40-018:" in modified_code
+
+
+def test_does_nothing_for_isocalendar_week():
+    given_code = """
+weeks = series.dt.isocalendar().week
+"""
+    modified_code = rewrite(given_code, PandasWeekOfYearRemoved())
+    assert modified_code == given_code
+
+
+def test_adds_code_hint_when_groupby_backfill_or_pad_is_used():
+    given_code = """
+filled = df.groupby("a").backfill()
+padded = df.groupby("a").pad()
+"""
+    modified_code = rewrite(given_code, PandasGroupByBackfillPadRemoved())
+    assert modified_code.count("# PY35-40-019:") == 2
+
+
+def test_adds_code_hint_when_categorical_inplace_is_used():
+    given_code = """
+cat.add_categories(["x"], inplace=True)
+"""
+    modified_code = rewrite(given_code, PandasCategoricalInplaceRemoved())
+    assert "# PY35-40-020:" in modified_code
+
+
+def test_does_nothing_for_categorical_without_inplace():
+    given_code = """
+cat = cat.add_categories(["x"])
+"""
+    modified_code = rewrite(given_code, PandasCategoricalInplaceRemoved())
+    assert modified_code == given_code
+
+
+def test_adds_code_hint_when_date_range_uses_closed():
+    given_code = """
+rng = ps.date_range("2021-01-01", periods=3, closed="left")
+"""
+    modified_code = rewrite(given_code, PandasDateRangeClosedRemoved())
+    assert "# PY35-40-021:" in modified_code
+
+
+def test_does_nothing_for_date_range_with_inclusive():
+    given_code = """
+rng = ps.date_range("2021-01-01", periods=3, inclusive="left")
+"""
+    modified_code = rewrite(given_code, PandasDateRangeClosedRemoved())
+    assert modified_code == given_code
+
+
+def test_adds_code_hint_when_between_time_uses_include_start():
+    given_code = """
+subset = df.between_time("0:00", "1:00", include_start=False)
+"""
+    modified_code = rewrite(given_code, PandasBetweenTimeInclusiveRemoved())
+    assert "# PY35-40-022:" in modified_code
+
+
+def test_adds_code_hint_when_between_uses_boolean_inclusive():
+    given_code = """
+mask = series.between(1, 5, inclusive=True)
+"""
+    modified_code = rewrite(given_code, PandasSeriesBetweenBooleanInclusiveRemoved())
+    assert "# PY35-40-023:" in modified_code
+
+
+def test_does_nothing_for_between_with_string_inclusive():
+    given_code = """
+mask = series.between(1, 5, inclusive="both")
+"""
+    modified_code = rewrite(given_code, PandasSeriesBetweenBooleanInclusiveRemoved())
+    assert modified_code == given_code
+
+
+def test_adds_code_hint_when_plot_uses_sort_columns():
+    given_code = """
+df.plot(sort_columns=True)
+"""
+    modified_code = rewrite(given_code, PandasPlotSortColumnsRemoved())
+    assert "# PY35-40-024:" in modified_code
+
+
+def test_adds_code_hint_when_to_latex_uses_col_space():
+    given_code = """
+latex = df.to_latex(col_space=10)
+"""
+    modified_code = rewrite(given_code, PandasToLatexColSpaceRemoved())
+    assert "# PY35-40-025:" in modified_code
+
+
+def test_adds_code_hint_when_to_excel_uses_removed_params():
+    given_code = """
+df.to_excel("out.xlsx", encoding="utf-8")
+"""
+    modified_code = rewrite(given_code, PandasToExcelParamsRemoved())
+    assert "# PY35-40-026:" in modified_code
+
+
+def test_adds_code_hint_when_read_csv_uses_removed_params():
+    given_code = """
+df = ps.read_csv("in.csv", squeeze=True)
+other = ps.read_excel("in.xlsx", convert_float=True)
+"""
+    modified_code = rewrite(given_code, PandasReadCsvExcelParamsRemoved())
+    assert modified_code.count("# PY35-40-027:") == 2
+
+
+def test_adds_code_hint_when_info_uses_null_counts():
+    given_code = """
+df.info(null_counts=True)
+"""
+    modified_code = rewrite(given_code, PandasInfoNullCountsRemoved())
+    assert "# PY35-40-028:" in modified_code
+
+
+def test_does_nothing_for_info_with_show_counts():
+    given_code = """
+df.info(show_counts=True)
+"""
+    modified_code = rewrite(given_code, PandasInfoNullCountsRemoved())
+    assert modified_code == given_code
+
+
+def test_adds_code_hint_when_assert_pandas_on_spark_equal_is_used():
+    given_code = """
+assertPandasOnSparkEqual(actual, expected)
+"""
+    modified_code = rewrite(given_code, AssertPandasOnSparkEqualRemoved())
+    assert "# PY35-40-029:" in modified_code
+    assert "assert_frame_equal" in modified_code


### PR DESCRIPTION
## Summary
This PR adds 19 new code hint transformers to detect deprecated and removed pandas-on-Spark APIs in the PySpark 3.5 to 4.0 migration path. These transformers identify usage of removed methods, properties, and parameters, emitting helpful comments to guide users through the migration process.

## Key Changes

- **Added 19 new transformer classes** (PY35-40-011 through PY35-40-029) to detect:
  - Removed methods: `append()`, `mad()`, `to_spark_io()`, `get_dtype_counts()`, `backfill()`, `pad()`
  - Removed properties/accessors: `koalas`, `asi8`, `is_all_dates`, `is_monotonic`, `week`/`weekofyear`
  - Removed function: `assertPandasOnSparkEqual()`
  - Removed parameters: `inplace` (categorical methods), `closed` (date_range), `include_start`/`include_end` (between_time), `inclusive` with boolean values (Series.between), `sort_columns` (plot), `col_space` (to_latex), `encoding`/`verbose` (to_excel), `squeeze`/`mangle_dupe_cols`/`convert_float` (read_csv/read_excel), `null_counts` (info)

- **Smart detection logic** including:
  - Exclusion of already-migrated patterns (e.g., `isocalendar().week` is not flagged)
  - Distinction between removed and replacement APIs (e.g., `is_monotonic` vs `is_monotonic_increasing`)
  - Support for both direct calls and attribute-based access patterns

- **Comprehensive test coverage** with 24 new test cases covering:
  - Basic detection of removed APIs
  - Edge cases and false-positive prevention
  - Parameter-specific detection

- **Updated transformer registry** to include all 19 new transformers in the `pyspark_35_to_40_transformers()` function

- **Updated README** with documentation of the new PY35-40-* rules

## Implementation Details

All transformers inherit from `StatementLineCommentWriter` and use CST matchers to identify deprecated patterns. Each transformer:
- Has a unique ID (PY35-40-011 through PY35-40-029)
- Provides a clear, actionable comment with migration guidance
- Supports configurable PySpark version in the comment
- Uses appropriate visitor methods (`visit_Call`, `visit_Attribute`) based on the API type

https://claude.ai/code/session_013QzdwWWdeRnHqdFAoqTqrV